### PR TITLE
fix a return that isn't a promise

### DIFF
--- a/src/d2lfetch-dedupe.js
+++ b/src/d2lfetch-dedupe.js
@@ -15,7 +15,7 @@ export class D2LFetchDedupe {
 		}
 
 		if (!next) {
-			return request;
+			return Promise.resolve(request);
 		}
 
 		const result = next(request);


### PR DESCRIPTION
This looks like a miss, even though we are not likely to ever hit this line (because `d2lfetch` will always pass in the `window.fetch` call as a final middleware) we shouldn't just return the `Request` if we ever do get here, we should return a `Promise` that resolves to it.