### PR TITLE
Only dedupe GET, HEAD, and OPTIONS requests

### DIFF
--- a/src/d2lfetch-dedupe.js
+++ b/src/d2lfetch-dedupe.js
@@ -9,6 +9,13 @@ export class D2LFetchDedupe {
 			return Promise.reject(new TypeError('Invalid request argument supplied; must be a valid window.Request object.'));
 		}
 
+		if (request.method !== 'GET' && request.method !== 'HEAD' && request.method !== 'OPTIONS') {
+			if (!next) {
+				return Promise.resolve(request);
+			}
+			return next(request);
+		}
+
 		const key = this._getKey(request);
 		if (this._inflightRequests[key]) {
 			return this._clone(this._inflightRequests[key]);


### PR DESCRIPTION
Addresses #8 by performing a hard pass on any request with method not `GET`, `HEAD`, or `OPTIONS`.