### PR TITLE
Make bower-able

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ script:
 - npm run build
 - npm run test:lint
 - wct --skip-plugin local
-- 'if [ "$TRAVIS_BRANCH" == "master" ]; then frauci-update-version && export TRAVIS_TAG=$(frauci-get-version) && npm run build && npm run publish-release; fi'
+- ./update.sh
 env:
   global:
-  - REPO_NAME=d2l-fetch-dedupe
   # SAUCE_USERNAME
   - secure: cIU1AnDjf1cOufp9k6sdtECS6QRA/MOU6z3bm5S7X/hXxZqhNu3ZpIbYJFWuwFoHk7Uyq4MJMY8ra5ZUuwjAMM7YZzj7ug7C3GvxXSoF9T6Uzsf1DPHHLk5nYxGTH5cpkMgeJrdeXqzjTQlcnV7ynC7iKJCMJoHkIXCVPYKZBwPZNCnZVuRZp/lWTZTJKE6MoSek3CCLQzpN1hzyu8kpPjpxbnFqdS5q9dCoyHPBvCJzq4KC+el69/On1meqMVt+fGU0+FhuV8d1y0/5HzUhZvsBgRq+2t88leSxoM/DejCtgxIzzjBv4683cDgwDoZ2RwZSb8BS9zopRg4ATgT16Qmc3PQQ3n7o34ZgTiO73tUoCGr4L4nQQ6B2/p9h3voP63aOyvt953VuzfYDTPeEQ73nfx7iehYfNybXzgtOhjrC6G6AUL9OW5YeaNcSOfplMyqvNlxvUXQIUeZD1V+lsQLo3LLLEIhjxyy6uP1U0V8uW847qDRYdYFp4nMXWXk6sz7NtcACyzA3sBVorTNznVRyPqeIso2jyZ27pkAhHImvpO7cGFdDzwnzx8LZZyvUlKn2o/IWqjlUDwdJj8AoPCXUs7IceulVFvqDxxheN8okh+nYnG6g4MeLYlvoonNIz4wzqTsz398pejGn6A6RcY7SRkudU6RBhUMAndbm2/o=
   # CDN_SECRET

--- a/README.md
+++ b/README.md
@@ -22,7 +22,19 @@ Reference the script in your html after your reference to `d2l-fetch` (see [here
 <script src="../dist/d2lfetch-dedupe.js"></script>
 ```
 
-This will add the `dedupe` middleware function to the `d2lfetch` object.
+This will add the `dedupe` middleware function to the `d2lfetch` object. Alternatively, you can install `d2l-fetch-dedupe` via bower:
+
+```sh
+bower install Brightspace/d2l-fetch-dedupe
+```
+
+and reference it as you would any other package:
+
+```html
+<link rel="import" href="../d2l-fetch-dedupe/d2l-fetch-dedupe.html">
+```
+
+Note that this version of `d2l-fetch-dedupe` is not transpiled - doing so is left up to the consumer.
 
 ### Dedupe
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "d2l-fetch-dedupe",
   "description": "Provides a middleware function for de-duplicating fetch requests for the same url+auth combination",
-  "main": "index.js",
+  "main": "d2l-fetch-dedupe.html",
   "authors": [
     "D2L Corporation"
   ],

--- a/d2l-fetch-dedupe.html
+++ b/d2l-fetch-dedupe.html
@@ -1,0 +1,2 @@
+<!-- CHANGES TO THIS FILE WILL BE LOST - IT IS AUTOMATICALLY GENERATED WHEN d2l-fetch-dedupe IS RELEASED -->
+<script src="https://s.brightspace.com/lib/d2lfetch-dedupe/0.10.0/d2lfetch-dedupe.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "d2l-fetch-dedupe",
-  "version": "0.10.0",
   "description": "Provides a middleware function for de-duplicating fetch requests for the same url+auth combination",
   "main": "index.js",
   "author": "D2L Corporation",
@@ -38,7 +37,6 @@
     "eslint": "^3.19.0",
     "eslint-config-brightspace": "^0.2.4",
     "eslint-plugin-html": "^2.0.1",
-    "frau-ci": "^1.33.0",
     "frau-publisher": "^2.6.2",
     "peanut-gallery": "^1.2.0",
     "web-component-tester": "^6.0.0",

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+if ! [ "$TRAVIS_BRANCH" == "master" ] || ! [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+	echo "Version is only bumped on master"
+	exit 0
+fi
+
+lastVersion=$(git describe --abbrev=0)
+versionRegex='^([0-9]+)\.([0-9]+)\.([0-9]+)$'
+if ! [[ $lastVersion =~ $versionRegex ]]; then
+	echo $lastVersion "is not a valid semver string"
+	exit 1
+fi
+
+majorVersion=${BASH_REMATCH[1]}
+minorVersion=${BASH_REMATCH[2]}
+patchVersion=${BASH_REMATCH[3]}
+
+lastLogMessage=$(git log -1 --pretty=format:%s%b)
+lastLogMessageShort=$(git log -1 --pretty=format:%s)
+
+majorRegex='\[increment major\]'
+patchRegex='\[increment patch\]'
+if [[ $lastLogMessage =~ $majorRegex ]]; then
+	majorVersion=$((majorVersion + 1))
+elif [[ $lastLogMessage =~ $patchRegex ]]; then
+	patchVersion=$((patchVersion + 1))
+else
+	minorVersion=$((minorVersion + 1))
+fi
+
+newVersion="${majorVersion}.${minorVersion}.${patchVersion}"
+
+# Add the upstream using GITHUB_RELEASE_TOKEN
+git remote add upstream "https://${GITHUB_RELEASE_TOKEN}@github.com/Brightspace/d2l-fetch-dedupe.git"
+
+# Pull the merge commit
+git pull upstream master
+git checkout upstream/master
+
+# Set config so this commit shows up as coming from Travis
+git config --global user.email "travis@travis-ci.com"
+git config --global user.name "Travis CI"
+
+echo "Updating from ${lastVersion} to ${newVersion}"
+echo "<!-- CHANGES TO THIS FILE WILL BE LOST - IT IS AUTOMATICALLY GENERATED WHEN d2l-fetch-dedupe IS RELEASED -->" > d2l-fetch-dedupe.html
+echo "<script src=\"https://s.brightspace.com/lib/d2lfetch-dedupe/"$newVersion"/d2lfetch-dedupe.js\"></script>" >> d2l-fetch-dedupe.html
+
+# Add the updated d2l-fetch-dedupe.html, and add a new tag to create the release
+git add .
+git commit -m "[skip ci] Update to ${newVersion}"
+git tag -a ${newVersion} -m "${newVersion} - ${lastLogMessageShort}"
+
+git status
+
+git push upstream HEAD:master --tags
+
+# Publish the release via frau-publisher
+export TRAVIS_TAG=$newVersion
+npm run publish-release


### PR DESCRIPTION
Adding this file allows us to use bower to control the versioning of this package, rather than using the CDNified versions and hoping that they won't conflict. This file is automatically updated by Travis to point at the CDN-ified script that will be generated by frau-ci in the next step. Since the new version isn't released until _after_ this commit is pushed, it does theoretically mean that if somebody pulled master at just the right moment, d2l-fetch-dedupe.html would be pointing to a non-existant file, but oh well. (If the consumer is using a proper bower version, this situation can't occur since the new version is only generated after the new file is CDN-ified.)