### PR TITLE
Add publish information to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,7 @@ the inflight request's Response.
 We recommend:
 
 * [promise-polyfill](https://github.com/PolymerLabs/promise-polyfill/)
+
+## Publishing
+
+The application will automatically increment the minor build version and publish a release version to the Brightspace CDN after merge to the `master` branch is complete. If you wish to increment the `patch` or `major` version instead please add **[increment patch]** or **[increment major]** to the notes inside your merge message.


### PR DESCRIPTION
An attempt to remove uncertainty for those updating the middleware.