### PR TITLE
docs: Update code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This will import the `auth` middleware
 Install the `dedupe` middleware to d2lfetch via the `use` function and then start making your requests.
 
 ```js
-d2lfetch.use({name: 'dedupe' fn: dedupe});
+d2lfetch.use({name: 'dedupe' fn: fetchDedupe});
 const response = await d2lfetch.fetch(
   new Request('http://example.com/api/someentity/')
 );


### PR DESCRIPTION
When working on https://github.com/Brightspace/parent-portal-ui/pull/1302, I noticed that the code sample is outdated since the function was renamed from `dedupe` to `fetchDedupe` in `2.0.0`. 

Would like to quickly fix it :)