### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   },
   "files": [
     "/src"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  }
 }


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564